### PR TITLE
Uygulamayı test etmek için gulp kullan

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,7 @@
 
 var gulp = require('gulp');
 var eslint = require('gulp-eslint');
+var mocha = require('gulp-mocha');
 
 gulp.task('lint', function() {
     return gulp.src([ '**/*.js', '!node_modules/**', '!coverage/**' ])
@@ -9,8 +10,10 @@ gulp.task('lint', function() {
         .pipe(eslint.failOnError());
 });
 
-gulp.task('default', [ 'lint' ]);
-gulp.task('development', [ 'lint' ]);
-gulp.task('test', [ 'lint' ]);
-gulp.task('beta', [ 'lint' ]);
-gulp.task('production', [ 'lint' ]);
+gulp.task('test', function() {
+    return gulp.src([ 'test/**/*.js' ], { read: false })
+        .pipe(mocha({ reporter: 'spec' }))
+        .pipe(eslint.failOnError());
+});
+
+gulp.task('default', [ 'test', 'lint' ]);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Açık Sözlük",
   "main": "app.js",
   "scripts": {
-    "test": "node_modules/.bin/mocha --sort"
+    "test": "gulp test"
   },
   "repository": {
     "type": "git",
@@ -17,11 +17,11 @@
   },
   "devDependencies": {
     "chai": "3.5.0",
-    "mocha": "2.4.5",
-    "sinon": "1.17.3",
     "ghooks": "1.0.3",
     "gulp": "3.9.1",
-    "gulp-eslint": "2.0.0"
+    "gulp-eslint": "2.0.0",
+    "gulp-mocha": "2.2.0",
+    "mocha": "2.4.5"
   },
   "config": {
     "ghooks": {


### PR DESCRIPTION
Bu yama gulp-mocha yardımı ile testlerin gulp ile çalıştırılmasını sağlıyor.

@ygunayer bunu feature-test-lint-hooks'a pushlamadan önce senin görüşlerini almak istedim.

Ayrıca birbirinin defautlltan farkı olamayan ve birbirinin aynı olan `development`, `beta` ve `production` görevlerini kaldırdım. İleride ihtiyaç duyduğumuz zaman ekleriz.

Son olarak *şimdilik* uygulama içerisinde hiç kullanılmayan sinon geliştirici bağımlılığını kaldırdım. İleride #3 ile express iskeletini eklediğimizde sinon (veya supertest) bağımlılığını ekleriz. Sinon tartışmasına #5 altında devam edebiliriz.